### PR TITLE
feat: sample.env 생성, 프론트에 dotenv 적용

### DIFF
--- a/client/sample.env
+++ b/client/sample.env
@@ -1,0 +1,2 @@
+REACT_APP_API_HOST={http://'퍼블릭 ec2 주소'(배포용) or http://localhost(개발용)}
+REACT_APP_API_PORT={API 포트번호}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -8,8 +8,10 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import { createHttpLink } from 'apollo-link-http';
 import { ApolloProvider } from '@apollo/react-hooks';
 
+const baseUrl = `${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}`;
+
 const client = new ApolloClient({
-  link: createHttpLink({ uri: 'http://localhost:3000/graphql' }),
+  link: createHttpLink({ uri: `${baseUrl}/graphql` }),
   cache: new InMemoryCache(),
 });
 

--- a/server/sample.env
+++ b/server/sample.env
@@ -1,0 +1,9 @@
+SSH_HOST={퍼블릭 ec2 주소}
+SSH_PORT={퍼블릭 ec2 포트}
+SSH_USER={퍼블릭 ec2 리눅스 계정}
+
+DB_HOST={프라이빗 DB ec2 주소}
+DB_USER={mysql 계정}
+DB_PORT={mysql 포트}
+DB_PASSWORD={mysql 비밀번호}
+DB_DATABASE={데이터베이스 이름}


### PR DESCRIPTION

## 체크리스트

- [x] 파일명/폴더명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 관련된 label 추가했는지 확인

## 설명
sample.env가 사라져서 다시 만듦.
프론트에도 .env 파일로 설정해줘야함

로컬에서 express 서버 돌리면서 개발하면 API_HOST를 localhost로하고
ec2에 배포했을땐 ec2 주소로 설정해주기