### PR TITLE
feat: 메인페이지 부모 카테고리별 제품리스트 (10개) 렌더링 구현

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,6 +4,7 @@ import { ThemeProvider, createGlobalStyle } from 'styled-components';
 import theme from './component/share/theme';
 import Mainpage from 'component/Mainpage';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import { FetchingProvider } from 'context/FetchingContext';
 
 const GlobalStyle = createGlobalStyle`
   @font-face {
@@ -35,7 +36,11 @@ function App() {
       <GlobalStyle />
       <Router>
         <Switch>
-          <Route path="/" exact component={Mainpage} />
+          <Route path="/" exact>
+            <FetchingProvider>
+              <Mainpage />
+            </FetchingProvider>
+          </Route>
           <Route path="/cart">장바구니페이지</Route>
           <Route path="/category">카테고리 페이지</Route>
           <Route path="/category_detail">상세 카테고리 페이지</Route>

--- a/client/src/component/Mainpage.js
+++ b/client/src/component/Mainpage.js
@@ -1,14 +1,15 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import ScrollTab from 'component/share/EventScrollTab';
-import Product from 'component/share/Product';
 import Header from 'component/share/Header';
 import Banner from 'component/mainpage/Banner';
 import Category from 'component/mainpage/Category';
 import Recommend from 'component/mainpage/Recommend';
+import MapProductList from 'component/mainpage/MapProductList';
 import { CategoryProvider, CategoryContext } from 'context/CategoryContext';
 import { EventScrollProvider } from 'context/EventScrollContext';
 import { RecommendContextProvider } from 'context/RecommendContext';
+import { FetchingContext } from 'context/FetchingContext';
 
 const Article = styled.article``;
 
@@ -24,18 +25,34 @@ const AdvertiseSection = styled(Section)``;
 
 const ProductSection = styled(Section)``;
 
-function MapProductList() {
-  const [title] = useContext(CategoryContext);
-  return (
-    <>
-      {title.map((item, idx) => (
-        <Product category={item.title} key={`productlist-${idx}`} />
-      ))}
-    </>
-  );
-}
-
 function Mainpage() {
+  const [fetching, setFetching] = useContext(FetchingContext);
+  const [end, setEnd] = useState(2);
+
+  // 스크롤 이벤트 핸들러
+  const handleScroll = () => {
+    const scrollHeight = document.documentElement.scrollHeight;
+    const scrollTop = document.documentElement.scrollTop;
+    const clientHeight = document.documentElement.clientHeight;
+    if (scrollTop + clientHeight >= scrollHeight && fetching === false) {
+      // 페이지 끝에 도달하면 추가 데이터를 받아온다
+
+      if (end < 10) {
+        setFetching(true);
+        setEnd(end + 2);
+      }
+    }
+  };
+
+  useEffect(() => {
+    // scroll event listener 등록
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      // scroll event listener 해제
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [end]);
+
   return (
     <>
       {/* 헤더 */}
@@ -60,7 +77,7 @@ function Mainpage() {
         {/* 제품 영역 */}
         <CategoryProvider>
           <ProductSection>
-            <MapProductList />
+            <MapProductList end={end} />
           </ProductSection>
         </CategoryProvider>
         {/* 광고영역 */}

--- a/client/src/component/Mainpage.js
+++ b/client/src/component/Mainpage.js
@@ -7,7 +7,9 @@ import Banner from 'component/mainpage/Banner';
 import Category from 'component/mainpage/Category';
 import Recommend from 'component/mainpage/Recommend';
 import { CategoryProvider, CategoryContext } from 'context/CategoryContext';
-import { EventScrollContext, EventScrollProvider } from 'context/EventScrollContext';
+import { EventScrollProvider } from 'context/EventScrollContext';
+import { RecommendContextProvider } from 'context/RecommendContext';
+
 const Article = styled.article``;
 
 const Section = styled.section`
@@ -27,7 +29,7 @@ function MapProductList() {
   return (
     <>
       {title.map((item, idx) => (
-        <Product category={item.title} key={idx} />
+        <Product category={item.title} key={`productlist-${idx}`} />
       ))}
     </>
   );
@@ -36,23 +38,32 @@ function MapProductList() {
 function Mainpage() {
   return (
     <>
+      {/* 헤더 */}
       <Header hasSearchBar />
+      {/* 배너 */}
       <Banner />
+      {/* 카테고리 */}
       <CategoryProvider>
         <Category />
       </CategoryProvider>
       <Article>
+        {/* 이벤트 스크롤 탭 */}
         <EventScrollProvider>
           <ScrollTab />
         </EventScrollProvider>
-        <RecommendSection>
-          <Recommend />
-        </RecommendSection>
+        {/* 반짝할인 */}
+        <RecommendContextProvider>
+          <RecommendSection>
+            <Recommend />
+          </RecommendSection>
+        </RecommendContextProvider>
+        {/* 제품 영역 */}
         <CategoryProvider>
           <ProductSection>
             <MapProductList />
           </ProductSection>
         </CategoryProvider>
+        {/* 광고영역 */}
         <AdvertiseSection>광고</AdvertiseSection>
       </Article>
     </>

--- a/client/src/component/mainpage/Category.js
+++ b/client/src/component/mainpage/Category.js
@@ -61,7 +61,7 @@ const CategoryTitle = styled.p`
 `;
 
 const Category = () => {
-  const [title] = useContext(CategoryContext);
+  const [categoryList] = useContext(CategoryContext);
 
   //오른쪽 클릭시 이미지 복사 기타 등등 이벤트 막아놓기
   const preventRightClick = useCallback((e) => {
@@ -81,14 +81,12 @@ const Category = () => {
         <DeliveryExpirationTime>| 24시까지 주문 예상</DeliveryExpirationTime>
       </NavTitle>
       <CategoryContainer onClick={preventRightClick}>
-        {title.map((item, idx) => {
-          return (
-            <CategoryItem key={`category-item-${idx}`}>
-              <CategoryImg src={`${item.src}`} alt={`${item.name}`} />
-              <CategoryTitle>{item.title}</CategoryTitle>
-            </CategoryItem>
-          );
-        })}
+        {categoryList.map((item, idx) => (
+          <CategoryItem key={`category-item-${idx}`}>
+            <CategoryImg src={`${item.src}`} alt={`${item.name}`} />
+            <CategoryTitle>{item.name}</CategoryTitle>
+          </CategoryItem>
+        ))}
       </CategoryContainer>
     </Nav>
   );

--- a/client/src/component/mainpage/Category.js
+++ b/client/src/component/mainpage/Category.js
@@ -83,7 +83,7 @@ const Category = () => {
       <CategoryContainer onClick={preventRightClick}>
         {title.map((item, idx) => {
           return (
-            <CategoryItem key={idx}>
+            <CategoryItem key={`category-item-${idx}`}>
               <CategoryImg src={`${item.src}`} alt={`${item.name}`} />
               <CategoryTitle>{item.title}</CategoryTitle>
             </CategoryItem>

--- a/client/src/component/mainpage/MapProductList.js
+++ b/client/src/component/mainpage/MapProductList.js
@@ -1,0 +1,20 @@
+import React, { useContext } from 'react';
+import { CategoryContext } from 'context/CategoryContext';
+import Product from 'component/share/Product';
+import { FetchingContext } from 'context/FetchingContext';
+
+const MapProductList = ({ end }) => {
+  const [categoryList] = useContext(CategoryContext);
+  const [fetching, setFetching] = useContext(FetchingContext);
+  setFetching(false);
+
+  return (
+    <>
+      {categoryList.slice(0, end).map((item, idx) => (
+        <Product category={item} key={`mainpage-product-${idx}`} />
+      ))}
+    </>
+  );
+};
+
+export default MapProductList;

--- a/client/src/component/mainpage/Recommend.js
+++ b/client/src/component/mainpage/Recommend.js
@@ -27,8 +27,6 @@ import {
 const Recommend = () => {
   const [recommendList, setRecommendList, selected, setSelected] = useContext(RecommendContext);
 
-  console.log(recommendList, selected);
-
   const updateImg = (id) => {
     setSelected(id - 1);
   };

--- a/client/src/component/mainpage/Recommend.js
+++ b/client/src/component/mainpage/Recommend.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { addCommaToNumber } from 'component/share/util';
-import { RECOMMEND_INTERVAL_TIME } from 'component/share/constant';
+import { RecommendContext } from 'context/RecommendContext';
 
 import {
   RecommendWrapper,
@@ -25,53 +25,9 @@ import {
 } from 'component/mainpage/RecommendStyle';
 
 const Recommend = () => {
-  const [recommendList, setRecommendList] = useState([
-    {
-      id: 1,
-      name: '왕교자',
-      img_url:
-        'https://images.unsplash.com/photo-1593642532744-d377ab507dc8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2250&q=80',
-      liked: false,
-      price: 5900,
-      discount_percent: 32,
-    },
-    {
-      id: 2,
-      name: '아름다운 자연',
-      img_url:
-        'https://images.unsplash.com/photo-1493246507139-91e8fad9978e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60',
-      liked: false,
-      price: 5900,
-      discount_percent: 30,
-    },
-    {
-      id: 3,
-      name: '노을 아름다워라라라',
-      img_url:
-        'https://images.unsplash.com/photo-1500964757637-c85e8a162699?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2578&q=80',
-      liked: true,
-      price: 5900,
-      discount_percent: 20,
-    },
-    {
-      id: 4,
-      name: '하얀 눈의 집',
-      img_url:
-        'https://images.unsplash.com/photo-1597673863457-55b714750858?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2250&q=80',
-      liked: false,
-      price: 5900,
-      discount_percent: 50,
-    },
-  ]);
+  const [recommendList, setRecommendList, selected, setSelected] = useContext(RecommendContext);
 
-  const [selected, setSelected] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setSelected((prevState) => (prevState + 1) % 4);
-    }, RECOMMEND_INTERVAL_TIME);
-    return () => clearInterval(interval);
-  }, []);
+  console.log(recommendList, selected);
 
   const updateImg = (id) => {
     setSelected(id - 1);

--- a/client/src/component/share/EventScrollTab.js
+++ b/client/src/component/share/EventScrollTab.js
@@ -91,8 +91,8 @@ function Category() {
       </div>
 
       {data.map((item, idx) => (
-        <RecommendContextProvider>
-          <TabPanel key={`tabpanel-${idx}`} value={value} index={idx}>
+        <RecommendContextProvider key={`tabpanel-${idx}`}>
+          <TabPanel value={value} index={idx}>
             {item.title} {item.component || '아직 컴포넌트 없음'}
           </TabPanel>
         </RecommendContextProvider>

--- a/client/src/component/share/EventScrollTab.js
+++ b/client/src/component/share/EventScrollTab.js
@@ -3,6 +3,7 @@ import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import { makeStyles, withStyles } from '@material-ui/core/styles';
 import { EventScrollContext } from 'context/EventScrollContext';
+import { RecommendContextProvider } from 'context/RecommendContext';
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -90,9 +91,11 @@ function Category() {
       </div>
 
       {data.map((item, idx) => (
-        <TabPanel key={`tabpanel-${idx}`} value={value} index={idx}>
-          {item.title} {item.component || '아직 컴포넌트 없음'}
-        </TabPanel>
+        <RecommendContextProvider>
+          <TabPanel key={`tabpanel-${idx}`} value={value} index={idx}>
+            {item.title} {item.component || '아직 컴포넌트 없음'}
+          </TabPanel>
+        </RecommendContextProvider>
       ))}
     </>
   );

--- a/client/src/component/share/EventScrollTab.js
+++ b/client/src/component/share/EventScrollTab.js
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import { makeStyles, withStyles } from '@material-ui/core/styles';
-import Recommend from 'component/mainpage/Recommend';
 import { EventScrollContext } from 'context/EventScrollContext';
 
 function TabPanel(props) {
@@ -85,13 +84,13 @@ function Category() {
           variant="scrollable"
         >
           {data.map((item, idx) => (
-            <StyledTab label={item.title} {...a11yProps({ idx })} />
+            <StyledTab key={`styled-tab-${idx}`} label={item.title} {...a11yProps({ idx })} />
           ))}
         </StyledTabs>
       </div>
 
       {data.map((item, idx) => (
-        <TabPanel value={value} index={idx}>
+        <TabPanel key={`tabpanel-${idx}`} value={value} index={idx}>
           {item.title} {item.component || '아직 컴포넌트 없음'}
         </TabPanel>
       ))}

--- a/client/src/component/share/Product.js
+++ b/client/src/component/share/Product.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import ProductItem from 'component/share/ProductItem';
+import { useQuery } from '@apollo/react-hooks';
+import { PRODUCTS_BY_CATEGORY_ID } from 'graphql/product';
 
 const ProductContainerHeader = styled.div`
   font-family: 'BMDOHYEON';
@@ -23,18 +25,25 @@ const HeaderBtn = styled.button`
 `;
 
 const Product = ({ category }) => {
+  const categoryId = category.id;
+  const { loading, error, data: products, refetch: refetchProducts } = useQuery(PRODUCTS_BY_CATEGORY_ID, {
+    variables: { categoryId },
+  });
+
+  if (loading || !products) return <div style={{ height: 100 }}>loading...</div>;
+  if (error) return <div>error</div>;
+  if (products) console.log(products);
+
   return (
     <>
       <ProductContainerHeader>
-        <h1>{category}</h1>
+        <h1>{category.name}</h1>
         <HeaderBtn>더보기</HeaderBtn>
       </ProductContainerHeader>
       <ProductContainer>
-        {Array(parseInt(10))
-          .fill()
-          .map((item, idx) => (
-            <ProductItem key={idx} />
-          ))}
+        {products.ProductsByCategoryId.map((item, idx) => {
+          return <ProductItem key={`productsByCategoryId-${idx}`} contents={item}></ProductItem>;
+        })}
       </ProductContainer>
     </>
   );

--- a/client/src/component/share/ProductItem.js
+++ b/client/src/component/share/ProductItem.js
@@ -29,13 +29,13 @@ const ProductContentRow = styled.p`
   padding: 2px 0;
 `;
 
-const ProductItem = () => {
+const ProductItem = ({ contents }) => {
   return (
     <EachItem>
-      <ProductImg img="https://source.unsplash.com/random/collections=food" />
+      <ProductImg img={contents.img_url} />
       <ProductContent>
-        <ProductContentRow>한입 쏙 비엔나</ProductContentRow>
-        <ProductContentRow>1190원</ProductContentRow>
+        <ProductContentRow>{contents.name}</ProductContentRow>
+        <ProductContentRow>{contents.price}원</ProductContentRow>
       </ProductContent>
     </EachItem>
   );

--- a/client/src/context/CategoryContext.js
+++ b/client/src/context/CategoryContext.js
@@ -1,6 +1,4 @@
-
 import React, { useState, useEffect, createContext } from 'react';
-
 import { useQuery } from '@apollo/react-hooks';
 import { CATEGORIES_PARENT } from 'graphql/category';
 import { IMG_URL } from 'component/share/constant';

--- a/client/src/context/CategoryContext.js
+++ b/client/src/context/CategoryContext.js
@@ -10,17 +10,18 @@ export const CategoryProvider = (props) => {
     CATEGORIES_PARENT
   );
 
-  const [title, setTitle] = useState([]);
+  const [categoryList, setCategoryList] = useState([]);
 
   useEffect(() => {
     if (categories) {
-      const title = categories.CategoriesParent.map((category, idx) => ({
-        title: category.name,
+      const categoryList = categories.CategoriesParent.map((category, idx) => ({
+        id: category.id,
+        name: category.name,
         src: `${IMG_URL}/category/${category.id}.png`,
       }));
-      title.push({ title: '더보기', src: `${IMG_URL}/more.png` });
-      setTitle(title);
+      categoryList.push({ id: 0, name: '더보기', src: `${IMG_URL}/more.png` });
+      setCategoryList(categoryList);
     }
   }, [categories]);
-  return <CategoryContext.Provider value={[title, setTitle]}>{props.children}</CategoryContext.Provider>;
+  return <CategoryContext.Provider value={[categoryList, setCategoryList]}>{props.children}</CategoryContext.Provider>;
 };

--- a/client/src/context/EventScrollContext.js
+++ b/client/src/context/EventScrollContext.js
@@ -1,7 +1,5 @@
 import React, { useState, createContext } from 'react';
 import Recommend from 'component/mainpage/Recommend';
-import { RecommendContextProvider } from 'context/RecommendContext';
-
 export const EventScrollContext = createContext();
 
 export const EventScrollProvider = ({ children }) => {
@@ -13,11 +11,7 @@ export const EventScrollProvider = ({ children }) => {
     },
     {
       title: '지금 뭐 먹지?',
-      component: (
-        <RecommendContextProvider>
-          <Recommend />
-        </RecommendContextProvider>
-      ),
+      component: <Recommend />,
     },
     {
       title: '새로 나왔어요',

--- a/client/src/context/EventScrollContext.js
+++ b/client/src/context/EventScrollContext.js
@@ -1,9 +1,10 @@
 import React, { useState, createContext } from 'react';
 import Recommend from 'component/mainpage/Recommend';
+import { RecommendContextProvider } from 'context/RecommendContext';
 
 export const EventScrollContext = createContext();
 
-export const EventScrollProvider = (props) => {
+export const EventScrollProvider = ({ children }) => {
   const [data, setData] = useState([
     { title: '널 위한 상품' },
     {
@@ -12,7 +13,11 @@ export const EventScrollProvider = (props) => {
     },
     {
       title: '지금 뭐 먹지?',
-      component: <Recommend />,
+      component: (
+        <RecommendContextProvider>
+          <Recommend />
+        </RecommendContextProvider>
+      ),
     },
     {
       title: '새로 나왔어요',
@@ -22,5 +27,5 @@ export const EventScrollProvider = (props) => {
     },
   ]);
   const [value, setValue] = useState(0);
-  return <EventScrollContext.Provider value={[data, value, setValue]}>{props.children}</EventScrollContext.Provider>;
+  return <EventScrollContext.Provider value={[data, value, setValue]}>{children}</EventScrollContext.Provider>;
 };

--- a/client/src/context/FetchingContext.js
+++ b/client/src/context/FetchingContext.js
@@ -1,0 +1,8 @@
+import React, { createContext, useState } from 'react';
+
+export const FetchingContext = createContext();
+
+export const FetchingProvider = (props) => {
+  const [fetching, setFetching] = useState(false);
+  return <FetchingContext.Provider value={[fetching, setFetching]}>{props.children}</FetchingContext.Provider>;
+};

--- a/client/src/context/ProductContext.js
+++ b/client/src/context/ProductContext.js
@@ -1,0 +1,26 @@
+import React, { useState, useEffect, createContext } from 'react';
+import { useQuery } from '@apollo/react-hooks';
+import { PRODUCTS_BY_CATEGORY_ID } from 'graphql/category';
+import { IMG_URL } from 'component/share/constant';
+
+export const CategoryContext = createContext();
+
+export const CategoryProvider = (props) => {
+  const { loading: loadingCategories, error: errorCategories, data: categories, refetch: refetchCategories } = useQuery(
+    PRODUCTS_BY_CATEGORY_ID
+  );
+
+  const [title, setTitle] = useState([]);
+
+  useEffect(() => {
+    if (categories) {
+      const title = categories.CategoriesParent.map((category, idx) => ({
+        title: category.name,
+        src: `${IMG_URL}/category/${category.id}.png`,
+      }));
+      title.push({ title: '더보기', src: `${IMG_URL}/more.png` });
+      setTitle(title);
+    }
+  }, [categories]);
+  return <CategoryContext.Provider value={[title, setTitle]}>{props.children}</CategoryContext.Provider>;
+};

--- a/client/src/context/ProductContext.js
+++ b/client/src/context/ProductContext.js
@@ -1,26 +1,33 @@
 import React, { useState, useEffect, createContext } from 'react';
 import { useQuery } from '@apollo/react-hooks';
-import { PRODUCTS_BY_CATEGORY_ID } from 'graphql/category';
-import { IMG_URL } from 'component/share/constant';
+import { PRODUCTS_BY_CATEGORY_ID } from 'graphql/product';
 
-export const CategoryContext = createContext();
+export const ProductContext = createContext();
 
-export const CategoryProvider = (props) => {
-  const { loading: loadingCategories, error: errorCategories, data: categories, refetch: refetchCategories } = useQuery(
-    PRODUCTS_BY_CATEGORY_ID
-  );
+export const ProductProvider = ({ categoryId, children }) => {
+  const {
+    loading: loadingProducts,
+    error: errorProducts,
+    data: products,
+    refetch: refetchProducts,
+  } = useQuery(PRODUCTS_BY_CATEGORY_ID, { variables: { categoryId } });
 
-  const [title, setTitle] = useState([]);
+  const [productList, setProductList] = useState([]);
 
   useEffect(() => {
-    if (categories) {
-      const title = categories.CategoriesParent.map((category, idx) => ({
-        title: category.name,
-        src: `${IMG_URL}/category/${category.id}.png`,
+    if (products) {
+      const data = products.ProductsByCategoryId.map((product, idx) => ({
+        name: product.name,
+        price: product.price,
+        category_id: product.category_id,
+        img_url: product.img_url,
       }));
-      title.push({ title: '더보기', src: `${IMG_URL}/more.png` });
-      setTitle(title);
+      setProductList(data);
+      console.log(productList);
     }
-  }, [categories]);
-  return <CategoryContext.Provider value={[title, setTitle]}>{props.children}</CategoryContext.Provider>;
+  }, [productList]);
+
+  return (
+    <ProductContext.Provider value={[loadingProducts, productList, setProductList]}>{children}</ProductContext.Provider>
+  );
 };

--- a/client/src/context/RecommendContext.js
+++ b/client/src/context/RecommendContext.js
@@ -1,0 +1,60 @@
+import React, { useState, createContext, useEffect } from 'react';
+import { RECOMMEND_INTERVAL_TIME } from 'component/share/constant';
+
+export const RecommendContext = createContext();
+
+export const RecommendContextProvider = ({ children }) => {
+  const [recommendList, setRecommendList] = useState([
+    {
+      id: 1,
+      name: '왕교자',
+      img_url:
+        'https://images.unsplash.com/photo-1593642532744-d377ab507dc8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2250&q=80',
+      liked: false,
+      price: 5900,
+      discount_percent: 32,
+    },
+    {
+      id: 2,
+      name: '아름다운 자연',
+      img_url:
+        'https://images.unsplash.com/photo-1493246507139-91e8fad9978e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60',
+      liked: false,
+      price: 5900,
+      discount_percent: 30,
+    },
+    {
+      id: 3,
+      name: '노을 아름다워라라라',
+      img_url:
+        'https://images.unsplash.com/photo-1500964757637-c85e8a162699?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2578&q=80',
+      liked: true,
+      price: 5900,
+      discount_percent: 20,
+    },
+    {
+      id: 4,
+      name: '하얀 눈의 집',
+      img_url:
+        'https://images.unsplash.com/photo-1597673863457-55b714750858?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2250&q=80',
+      liked: false,
+      price: 5900,
+      discount_percent: 50,
+    },
+  ]);
+
+  const [selected, setSelected] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setSelected((selected + 1) % 4);
+    }, RECOMMEND_INTERVAL_TIME);
+    return () => clearInterval(interval);
+  });
+
+  return (
+    <RecommendContext.Provider value={[recommendList, setRecommendList, selected, setSelected]}>
+      {children}
+    </RecommendContext.Provider>
+  );
+};

--- a/server/db/query/product.js
+++ b/server/db/query/product.js
@@ -11,7 +11,9 @@ const getProductByIdQuery = (id) => {
 };
 
 const getProductsByCategoryIdQuery = (categoryId) => {
-  const getProductsByCategoryIdFormat = `select * from product where category_id=?`;
+  const getProductsByCategoryIdFormat = `select * from product where category_id in (select id from category where parent_name=(select name from category where id=?))`;
+
+  //  = `select * from product where category_id=${category_ids}`;
   return mysql2.format(getProductsByCategoryIdFormat, [categoryId]);
 };
 

--- a/server/db/query/product.js
+++ b/server/db/query/product.js
@@ -11,9 +11,8 @@ const getProductByIdQuery = (id) => {
 };
 
 const getProductsByCategoryIdQuery = (categoryId) => {
-  const getProductsByCategoryIdFormat = `select * from product where category_id in (select id from category where parent_name=(select name from category where id=?))`;
+  const getProductsByCategoryIdFormat = `select * from product where category_id in (select id from category where parent_name=(select name from category where id=?)) limit 10`;
 
-  //  = `select * from product where category_id=${category_ids}`;
   return mysql2.format(getProductsByCategoryIdFormat, [categoryId]);
 };
 

--- a/server/db/share/db.config.js
+++ b/server/db/share/db.config.js
@@ -8,6 +8,7 @@ const sshConf = {
   host: process.env.SSH_HOST,
   port: process.env.SSH_PORT,
   user: process.env.SSH_USER,
+  readyTimeout: 99999,
   privateKey: fs.readFileSync(path.join(__dirname, 'bmart-3.pem')), //리눅스에서 ssh접속시 사용할 키!!
 };
 


### PR DESCRIPTION
## 체크리스트

- [x] 파일명/폴더명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 관련된 label 추가했는지 확인

## 관련 이슈

- closed #27 

## 설명
- 부모 카테고리별로 제품리스트 가져오도록 백엔드 쿼리 및 클라이언트 qraphql 쿼리 구현 
- 메인페이지에서 2개씩 카테고리별 제품리스트를 가져오도록 인피니티스크롤 구현 

> 추가 구현할 사항: 인피니티스크롤에서 이미 가져온 제품 리스트를 저장하는 로직 작성 필요 -> context api 로구현


## 설명

>  메인 페이지에 들어왔을 때 스크롤에 따라서 부모 카테고리별 제품 데이터를 렌더링하도록 구현한다

- [x] 부모 아이디를 받아 연관된 제품 리스트 가져오도록 쿼리 구현 
- [x] 프론트에서 graphql로 제품 리스트 가져오도록 구현 
- [x] 스크롤에따라 부분적으로 데이터를 가져오도록 인피니티 스크롤 구현 

