### PR TITLE
[FE/Main page] refactor: mainpage infinite scroll 수정

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,0 +1,7 @@
+{
+    "env": {
+      "production": {
+        "plugins": ["transform-remove-console"]
+      }
+    }
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3440,6 +3440,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
+    "babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A="
+    },
     "babel-preset-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",
     "apollo-link-http": "^1.5.17",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "graphql": "^15.3.0",
     "graphql-tag": "^2.11.0",
     "react": "^16.13.1",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,6 +6,8 @@ import Mainpage from 'component/Mainpage';
 import ParentCategory from 'component/ParentCategory';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import { FetchingProvider } from 'context/FetchingContext';
+import { CategoryProvider } from 'context/CategoryContext';
+import { ProductProvider } from 'context/ProductContext';
 
 const GlobalStyle = createGlobalStyle`
   @font-face {
@@ -38,9 +40,13 @@ function App() {
       <Router>
         <Switch>
           <Route path="/" exact>
-            <FetchingProvider>
-              <Mainpage />
-            </FetchingProvider>
+            <ProductProvider>
+              <CategoryProvider>
+                <FetchingProvider>
+                  <Mainpage />
+                </FetchingProvider>
+              </CategoryProvider>
+            </ProductProvider>
           </Route>
           <Route path="/cart">장바구니페이지</Route>
           <Route path="/category/:category_id" component={ParentCategory} />

--- a/client/src/component/Mainpage.js
+++ b/client/src/component/Mainpage.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import ScrollTab from 'component/share/EventScrollTab';
 import Header from 'component/share/Header';
@@ -6,10 +6,8 @@ import Banner from 'component/mainpage/Banner';
 import Category from 'component/mainpage/Category';
 import Recommend from 'component/mainpage/Recommend';
 import MapProductList from 'component/mainpage/MapProductList';
-import { CategoryProvider, CategoryContext } from 'context/CategoryContext';
 import { EventScrollProvider } from 'context/EventScrollContext';
 import { RecommendContextProvider } from 'context/RecommendContext';
-import { FetchingContext } from 'context/FetchingContext';
 
 const Article = styled.article``;
 
@@ -26,33 +24,6 @@ const AdvertiseSection = styled(Section)``;
 const ProductSection = styled(Section)``;
 
 function Mainpage() {
-  const [fetching, setFetching] = useContext(FetchingContext);
-  const [end, setEnd] = useState(2);
-
-  // 스크롤 이벤트 핸들러
-  const handleScroll = () => {
-    const scrollHeight = document.documentElement.scrollHeight;
-    const scrollTop = document.documentElement.scrollTop;
-    const clientHeight = document.documentElement.clientHeight;
-    if (scrollTop + clientHeight >= scrollHeight && fetching === false) {
-      // 페이지 끝에 도달하면 추가 데이터를 받아온다
-
-      if (end < 10) {
-        setFetching(true);
-        setEnd(end + 2);
-      }
-    }
-  };
-
-  useEffect(() => {
-    // scroll event listener 등록
-    window.addEventListener('scroll', handleScroll);
-    return () => {
-      // scroll event listener 해제
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, [end]);
-
   return (
     <>
       {/* 헤더 */}
@@ -60,9 +31,8 @@ function Mainpage() {
       {/* 배너 */}
       <Banner />
       {/* 카테고리 */}
-      <CategoryProvider>
-        <Category />
-      </CategoryProvider>
+      <Category />
+
       <Article>
         {/* 이벤트 스크롤 탭 */}
         <EventScrollProvider>
@@ -75,11 +45,9 @@ function Mainpage() {
           </RecommendSection>
         </RecommendContextProvider>
         {/* 제품 영역 */}
-        <CategoryProvider>
-          <ProductSection>
-            <MapProductList end={end} />
-          </ProductSection>
-        </CategoryProvider>
+        <ProductSection>
+          <MapProductList />
+        </ProductSection>
         {/* 광고영역 */}
         <AdvertiseSection>광고</AdvertiseSection>
       </Article>

--- a/client/src/component/ParentCategory.js
+++ b/client/src/component/ParentCategory.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import Header from 'component/share/Header';
 import ProductList from 'component/share/ProductList';
 import Advertise from 'component/share/Advertise';
@@ -51,35 +51,18 @@ function ParentCategory(props) {
   const categoryId = parseInt(splitUrl[splitUrl.length - 1]);
 
   // 자식 카테고리 요청
-  const {
-    loading: loadingCategories,
-    error: errorCategories,
-    data: childcategories,
-    refetch: refetchCategories,
-  } = useQuery(CATEGORIES_CHILD, {
+  const { loading: loadingCategories, data: childcategories } = useQuery(CATEGORIES_CHILD, {
     variables: {
       parentId: categoryId,
     },
   });
 
   // 부모 카테고리 제품 데이터 요청
-  const { loading: loadingProducts, error: errorProducts, data: products, refetch: refetchProducts } = useQuery(
-    PRODUCTS_BY_CATEGORY_ID,
-    {
-      variables: {
-        categoryId: categoryId,
-      },
-    }
-  );
-
-  useEffect(() => {
-    if (childcategories) {
-      console.log('childcategories : ', childcategories);
-    }
-    if (products) {
-      console.log('products :', products);
-    }
-  }, [childcategories, products]);
+  const { loading: loadingProducts, data: products } = useQuery(PRODUCTS_BY_CATEGORY_ID, {
+    variables: {
+      categoryId: categoryId,
+    },
+  });
 
   return (
     <>
@@ -93,7 +76,6 @@ function ParentCategory(props) {
         )}
         <ProductSection>
           <ListControlBar />
-          {/* <Product category={categoryId} /> */}
           {!loadingProducts ? (
             <ProductList productItems={products.ProductsByCategoryId} />
           ) : (

--- a/client/src/component/ParentCategory.js
+++ b/client/src/component/ParentCategory.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Header from 'component/share/Header';
 import ProductList from 'component/share/ProductList';
-import Product from 'component/share/Product';
 import Advertise from 'component/share/Advertise';
 import styled from 'styled-components';
 import { useQuery } from '@apollo/react-hooks';

--- a/client/src/component/mainpage/MapProductList.js
+++ b/client/src/component/mainpage/MapProductList.js
@@ -8,6 +8,8 @@ const MapProductList = ({ end }) => {
   const [fetching, setFetching] = useContext(FetchingContext);
   setFetching(false);
 
+ 
+
   return (
     <>
       {categoryList.slice(0, end).map((item, idx) => (

--- a/client/src/component/mainpage/MapProductList.js
+++ b/client/src/component/mainpage/MapProductList.js
@@ -1,20 +1,142 @@
-import React, { useContext } from 'react';
-import { CategoryContext } from 'context/CategoryContext';
+import React, { useContext, useState, useEffect } from 'react';
+import styled, { keyframes } from 'styled-components';
 import Product from 'component/share/Product';
 import { FetchingContext } from 'context/FetchingContext';
+import { ProductContext } from 'context/ProductContext';
+import { PRODUCTS_BY_CATEGORY_ID } from 'graphql/product';
+import { useQuery } from '@apollo/react-hooks';
 
-const MapProductList = ({ end }) => {
-  const [categoryList] = useContext(CategoryContext);
+const rotateOne = keyframes`
+    0% {
+      transform: rotateX(35deg) rotateY(-45deg) rotateZ(0deg);
+    }
+    100% {
+      transform: rotateX(35deg) rotateY(-45deg) rotateZ(360deg);
+    }
+  `;
+const rotateTwo = keyframes`
+    0% {
+      transform: rotateX(50deg) rotateY(10deg) rotateZ(0deg);
+    }
+    100% {
+      transform: rotateX(50deg) rotateY(10deg) rotateZ(360deg);
+    }
+  `;
+
+const rotateThree = keyframes`
+    0% {
+      transform: rotateX(35deg) rotateY(55deg) rotateZ(0deg);
+    }
+    100% {
+      transform: rotateX(35deg) rotateY(55deg) rotateZ(360deg);
+    }
+  `;
+
+const LoadingContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 200px;
+  position: relative;
+
+  & > div {
+    margin: 10px 0;
+  }
+`;
+
+const Loader = styled.div`
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  perspective: 800px;
+`;
+
+const Inner = styled.div`
+  position: absolute;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+`;
+
+const InnerOne = styled(Inner)`
+  left: 0%;
+  top: 0%;
+  animation: ${rotateOne} 1s linear infinite;
+  border-bottom: 3px solid black;
+`;
+const InnerTwo = styled(Inner)`
+  right: 0%;
+  top: 0%;
+  animation: ${rotateTwo} 1s linear infinite;
+  border-right: 3px solid black;
+`;
+const InnerThree = styled(Inner)`
+  right: 0%;
+  bottom: 0%;
+  animation: ${rotateThree} 1s linear infinite;
+  border-top: 3px solid black;
+`;
+
+const MapProductList = () => {
   const [fetching, setFetching] = useContext(FetchingContext);
-  setFetching(false);
+  const [productList, setProductList] = useContext(ProductContext);
+  const [start, setStart] = useState(1);
 
- 
+  const categoryId = start;
+  const { loading, error, data: products, refetch: refetchProducts } = useQuery(PRODUCTS_BY_CATEGORY_ID, {
+    variables: { categoryId },
+  });
+
+  // 스크롤 이벤트 핸들
+  const handleScroll = () => {
+    const scrollHeight = document.documentElement.scrollHeight;
+    const scrollTop = document.documentElement.scrollTop;
+    const clientHeight = document.documentElement.clientHeight;
+    if (scrollTop + clientHeight >= scrollHeight * 0.5 && fetching === false) {
+      // 페이지 끝에 도달하면 추가 데이터를 받아온다
+      if (start < 9) {
+        setStart(start + 1);
+        setFetching(true);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (products) {
+      setFetching(false);
+      productList[start] = products.ProductsByCategoryId;
+      setProductList(productList);
+    }
+    // scroll event listener 등록
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      // scroll event listener 해제
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [products, fetching]);
+
+  if (error) return <div>error</div>;
 
   return (
     <>
-      {categoryList.slice(0, end).map((item, idx) => (
-        <Product category={item} key={`mainpage-product-${idx}`} />
-      ))}
+      {!loading ? (
+        <Product />
+      ) : (
+        <>
+          <Product />
+          <LoadingContainer>
+            <Loader>
+              <InnerOne />
+              <InnerTwo />
+              <InnerThree />
+            </Loader>
+            <div>데이터 불러오는 중...</div>
+          </LoadingContainer>
+        </>
+      )}
     </>
   );
 };

--- a/client/src/component/mainpage/MapProductList.js
+++ b/client/src/component/mainpage/MapProductList.js
@@ -86,7 +86,7 @@ const MapProductList = () => {
   const [start, setStart] = useState(1);
 
   const categoryId = start;
-  const { loading, error, data: products, refetch: refetchProducts } = useQuery(PRODUCTS_BY_CATEGORY_ID, {
+  const { loading, error, data: products } = useQuery(PRODUCTS_BY_CATEGORY_ID, {
     variables: { categoryId },
   });
 
@@ -111,10 +111,10 @@ const MapProductList = () => {
       setProductList(productList);
     }
     // scroll event listener 등록
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScroll, { passive: true });
     return () => {
       // scroll event listener 해제
-      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('scroll', handleScroll, { passive: true });
     };
   }, [products, fetching]);
 

--- a/client/src/component/mainpage/MapProductList.js
+++ b/client/src/component/mainpage/MapProductList.js
@@ -83,7 +83,7 @@ const InnerThree = styled(Inner)`
 const MapProductList = () => {
   const [fetching, setFetching] = useContext(FetchingContext);
   const [productList, setProductList] = useContext(ProductContext);
-  const [start, setStart] = useState(1);
+  const [start, setStart] = useState(2);
 
   const categoryId = start;
   const { loading, error, data: products } = useQuery(PRODUCTS_BY_CATEGORY_ID, {

--- a/client/src/component/share/EventScrollTab.js
+++ b/client/src/component/share/EventScrollTab.js
@@ -69,7 +69,7 @@ function Category() {
   const classes = useStyles();
   const [data, value, setValue] = useContext(EventScrollContext);
 
-  const handleChange = (event, newValue) => {
+  const handleChange = (newValue) => {
     setValue(newValue);
   };
 

--- a/client/src/component/share/EventScrollTab.js
+++ b/client/src/component/share/EventScrollTab.js
@@ -69,7 +69,7 @@ function Category() {
   const classes = useStyles();
   const [data, value, setValue] = useContext(EventScrollContext);
 
-  const handleChange = (newValue) => {
+  const handleChange = (event, newValue) => {
     setValue(newValue);
   };
 
@@ -77,7 +77,6 @@ function Category() {
     <>
       <div className={classes.demo2}>
         <StyledTabs
-          variant="fullWidth"
           value={value}
           onChange={handleChange}
           aria-label="nav tabs example"

--- a/client/src/component/share/Product.js
+++ b/client/src/component/share/Product.js
@@ -30,7 +30,7 @@ const Product = ({ category }) => {
     variables: { categoryId },
   });
 
-  if (loading || !products) return <div style={{ height: 100 }}>loading...</div>;
+  if (loading || !products) return <div>loading...</div>;
   if (error) return <div>error</div>;
   if (products) console.log(products);
 

--- a/client/src/component/share/Product.js
+++ b/client/src/component/share/Product.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
-import ProductItem from 'component/share/ProductItem';
-import { useQuery } from '@apollo/react-hooks';
-import { PRODUCTS_BY_CATEGORY_ID } from 'graphql/product';
+import ProductList from 'component/share/ProductList';
+import { ProductContext } from 'context/ProductContext';
+import { CategoryContext } from 'context/CategoryContext';
 
 const ProductContainerHeader = styled.div`
   font-family: 'BMDOHYEON';
@@ -26,27 +26,30 @@ const HeaderBtn = styled.button`
 
 //부모한테 category_id를 받아서 본인이 api를 통해 데이터를 가져옴 >
 
-const Product = ({ category }) => {
-  const categoryId = category.id;
-  const { loading, error, data: products, refetch: refetchProducts } = useQuery(PRODUCTS_BY_CATEGORY_ID, {
-    variables: { categoryId },
-  });
-
-  if (loading || !products) return <div>loading...</div>;
-  if (error) return <div>error</div>;
-  if (products) console.log(products);
+const Product = () => {
+  const [productList] = useContext(ProductContext);
+  const [categoryList] = useContext(CategoryContext);
 
   return (
     <>
-      <ProductContainerHeader>
-        <h1>{category.name}</h1>
-        <HeaderBtn>더보기</HeaderBtn>
-      </ProductContainerHeader>
-      <ProductContainer>
-        {products.ProductsByCategoryId.map((item, idx) => {
-          return <ProductItem key={`productsByCategoryId-${idx}`} content={item}></ProductItem>;
-        })}
-      </ProductContainer>
+      {productList.length
+        ? productList.map((item, idx) => {
+            if (idx === 0) return;
+            else {
+              return (
+                <div key={`product-container-header-${idx}`}>
+                  <ProductContainerHeader>
+                    <h1>{categoryList.length ? categoryList[idx - 1].name : ''}</h1>
+                    <HeaderBtn>더보기</HeaderBtn>
+                  </ProductContainerHeader>
+                  <ProductContainer>
+                    <ProductList productItems={item} />
+                  </ProductContainer>
+                </div>
+              );
+            }
+          })
+        : ''}
     </>
   );
 };

--- a/client/src/component/share/Product.js
+++ b/client/src/component/share/Product.js
@@ -34,7 +34,7 @@ const Product = () => {
     <>
       {productList.length
         ? productList.map((item, idx) => {
-            if (idx === 0) return;
+            if (idx === 0) return null;
             else {
               return (
                 <div key={`product-container-header-${idx}`}>

--- a/client/src/component/share/ProductItem.js
+++ b/client/src/component/share/ProductItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { IMG_URL } from 'component/share/constant';
+import { addCommaToNumber } from 'component/share/util';
 const EachItem = styled.div`
   font-size: 0.8em;
   width: 45%;
@@ -35,7 +36,7 @@ const ProductItem = ({ content }) => {
       <ProductImg img={content.img_url} />
       <ProductContent>
         <ProductContentRow>{content.name}</ProductContentRow>
-        <ProductContentRow>{content.price}원</ProductContentRow>
+        <ProductContentRow>{addCommaToNumber(content.price)}원</ProductContentRow>
       </ProductContent>
     </EachItem>
   );

--- a/client/src/component/share/ProductItem.js
+++ b/client/src/component/share/ProductItem.js
@@ -22,12 +22,12 @@ const ProductImg = styled.img.attrs((props) => ({ src: props.img }))`
 `;
 
 const ProductContent = styled.div`
-  width: 100%;
+  width: 110%;
   padding: 5px 0;
 `;
 
 const ProductContentRow = styled.p`
-  padding: 2px 0;
+  padding: 2px 0 2px 10px;
 `;
 
 const ProductItem = ({ content }) => {

--- a/client/src/component/share/ProductItem.js
+++ b/client/src/component/share/ProductItem.js
@@ -20,15 +20,6 @@ const ProductImg = styled.img.attrs((props) => ({ src: props.img }))`
   box-shadow: inset 0 0 7px ${(props) => props.theme.color.darkGray};
 `;
 
-// {
-//   id: 4,
-//   name: '제품1',
-//   price: 4500,
-//   img_url: 'https://img-cf.kurly.com/shop/data/goods/1562318813669l0.jpg',
-//   category_id: 21,
-//   discount_percent: 0,
-// },
-
 const ProductContent = styled.div`
   width: 100%;
   padding: 5px 0;

--- a/client/src/component/share/ProductList.js
+++ b/client/src/component/share/ProductList.js
@@ -9,7 +9,7 @@ const ProductContainer = styled.div`
 `;
 
 const ProductList = ({ productItems }) => {
-  // console.log('productItems : ', productItems);
+
   return (
     <ProductContainer>
       {productItems.map((item, idx) => (

--- a/client/src/context/CategoryContext.js
+++ b/client/src/context/CategoryContext.js
@@ -12,6 +12,7 @@ export const CategoryProvider = (props) => {
 
   const [categoryList, setCategoryList] = useState([]);
 
+
   useEffect(() => {
     if (categories) {
       const categoryList = categories.CategoriesParent.map((category, idx) => ({

--- a/client/src/context/CategoryContext.js
+++ b/client/src/context/CategoryContext.js
@@ -6,12 +6,9 @@ import { IMG_URL } from 'component/share/constant';
 export const CategoryContext = createContext();
 
 export const CategoryProvider = (props) => {
-  const { loading: loadingCategories, error: errorCategories, data: categories, refetch: refetchCategories } = useQuery(
-    CATEGORIES_PARENT
-  );
+  const { loading, error, data: categories, refetch } = useQuery(CATEGORIES_PARENT);
 
   const [categoryList, setCategoryList] = useState([]);
-
 
   useEffect(() => {
     if (categories) {

--- a/client/src/context/CategoryContext.js
+++ b/client/src/context/CategoryContext.js
@@ -6,7 +6,7 @@ import { IMG_URL } from 'component/share/constant';
 export const CategoryContext = createContext();
 
 export const CategoryProvider = (props) => {
-  const { loading, error, data: categories, refetch } = useQuery(CATEGORIES_PARENT);
+  const { data: categories } = useQuery(CATEGORIES_PARENT);
 
   const [categoryList, setCategoryList] = useState([]);
 

--- a/client/src/context/EventScrollContext.js
+++ b/client/src/context/EventScrollContext.js
@@ -3,7 +3,7 @@ import Recommend from 'component/mainpage/Recommend';
 export const EventScrollContext = createContext();
 
 export const EventScrollProvider = ({ children }) => {
-  const [data, setData] = useState([
+  const [data] = useState([
     { title: '널 위한 상품' },
     {
       title: '번쩍 할인',

--- a/client/src/context/FetchingContext.js
+++ b/client/src/context/FetchingContext.js
@@ -3,6 +3,6 @@ import React, { createContext, useState } from 'react';
 export const FetchingContext = createContext();
 
 export const FetchingProvider = (props) => {
-  const [fetching, setFetching] = useState(false);
+  const [fetching, setFetching] = useState(true);
   return <FetchingContext.Provider value={[fetching, setFetching]}>{props.children}</FetchingContext.Provider>;
 };

--- a/client/src/context/ProductContext.js
+++ b/client/src/context/ProductContext.js
@@ -4,22 +4,12 @@ import { PRODUCTS_BY_CATEGORY_ID } from 'graphql/product';
 
 export const ProductContext = createContext();
 
-export const ProductProvider = ({ categoryId, children }) => {
-  const {
-    loading: loadingProducts,
-    error: errorProducts,
-    data: products,
-    refetch: refetchProducts,
-  } = useQuery(PRODUCTS_BY_CATEGORY_ID, { variables: { categoryId } });
+export const ProductProvider = ({ children }) => {
+  const { loading, error, data: products, refetch } = useQuery(PRODUCTS_BY_CATEGORY_ID, { variables: 1 });
 
   const [productList, setProductList] = useState([]);
-  // const [productList, setProductList] = useState({});
-
-  // {1:[{},{},{}]}
 
   useEffect(() => {
-    // const arr = { categoryId: [] };
-
     if (products) {
       const data = products.ProductsByCategoryId.map((product, idx) => ({
         name: product.name,
@@ -27,12 +17,9 @@ export const ProductProvider = ({ categoryId, children }) => {
         category_id: product.category_id,
         img_url: product.img_url,
       }));
-      // arr[categoryId] = data;
-      // setProductList(...productList, arr);
+      setProductList(data);
     }
   }, [productList]);
 
-  return (
-    <ProductContext.Provider value={[loadingProducts, productList, setProductList]}>{children}</ProductContext.Provider>
-  );
+  return <ProductContext.Provider value={[productList, setProductList]}>{children}</ProductContext.Provider>;
 };

--- a/client/src/context/ProductContext.js
+++ b/client/src/context/ProductContext.js
@@ -13,8 +13,13 @@ export const ProductProvider = ({ categoryId, children }) => {
   } = useQuery(PRODUCTS_BY_CATEGORY_ID, { variables: { categoryId } });
 
   const [productList, setProductList] = useState([]);
+  // const [productList, setProductList] = useState({});
+
+  // {1:[{},{},{}]}
 
   useEffect(() => {
+    // const arr = { categoryId: [] };
+
     if (products) {
       const data = products.ProductsByCategoryId.map((product, idx) => ({
         name: product.name,
@@ -22,8 +27,8 @@ export const ProductProvider = ({ categoryId, children }) => {
         category_id: product.category_id,
         img_url: product.img_url,
       }));
-      setProductList(data);
-      console.log(productList);
+      // arr[categoryId] = data;
+      // setProductList(...productList, arr);
     }
   }, [productList]);
 

--- a/client/src/context/ProductContext.js
+++ b/client/src/context/ProductContext.js
@@ -12,6 +12,7 @@ export const ProductProvider = ({ children }) => {
 
   useEffect(() => {
     if (products) {
+      const data = products.ProductsByCategoryId;
       productList[categoryId] = data;
       setProductList(productList);
     }

--- a/client/src/context/ProductContext.js
+++ b/client/src/context/ProductContext.js
@@ -5,19 +5,15 @@ import { PRODUCTS_BY_CATEGORY_ID } from 'graphql/product';
 export const ProductContext = createContext();
 
 export const ProductProvider = ({ children }) => {
-  const { data: products } = useQuery(PRODUCTS_BY_CATEGORY_ID, { variables: 1 });
+  const categoryId = 1;
+  const { loading, data: products } = useQuery(PRODUCTS_BY_CATEGORY_ID, { variables: { categoryId } });
 
   const [productList, setProductList] = useState([]);
 
   useEffect(() => {
     if (products) {
-      const data = products.ProductsByCategoryId.map((product, idx) => ({
-        name: product.name,
-        price: product.price,
-        category_id: product.category_id,
-        img_url: product.img_url,
-      }));
-      setProductList(data);
+      productList[categoryId] = data;
+      setProductList(productList);
     }
   }, [products]);
 

--- a/client/src/context/ProductContext.js
+++ b/client/src/context/ProductContext.js
@@ -5,7 +5,7 @@ import { PRODUCTS_BY_CATEGORY_ID } from 'graphql/product';
 export const ProductContext = createContext();
 
 export const ProductProvider = ({ children }) => {
-  const { loading, error, data: products, refetch } = useQuery(PRODUCTS_BY_CATEGORY_ID, { variables: 1 });
+  const { data: products } = useQuery(PRODUCTS_BY_CATEGORY_ID, { variables: 1 });
 
   const [productList, setProductList] = useState([]);
 
@@ -19,7 +19,7 @@ export const ProductProvider = ({ children }) => {
       }));
       setProductList(data);
     }
-  }, [productList]);
+  }, [products]);
 
   return <ProductContext.Provider value={[productList, setProductList]}>{children}</ProductContext.Provider>;
 };

--- a/server/db/share/db.config.js
+++ b/server/db/share/db.config.js
@@ -8,7 +8,6 @@ const sshConf = {
   host: process.env.SSH_HOST,
   port: process.env.SSH_PORT,
   user: process.env.SSH_USER,
-  readyTimeout: 99999,
   privateKey: fs.readFileSync(path.join(__dirname, 'bmart-3.pem')), //리눅스에서 ssh접속시 사용할 키!!
 };
 


### PR DESCRIPTION
## 체크리스트

- [x] 파일명/폴더명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 관련된 label 추가했는지 확인

## 관련 이슈

- closes #27 

## 설명

- 같은 데이터를 여러번 쿼리를 날려서 가져오지 않도록 수정했습니다

- 한 번 가져온 데이터는 productList context에 저장하여 렌더링시 이 state정보를 이용해 ProductItem컴포넌트를 렌더링 하도록 수정했습니다

- 로딩시 보여줄 아이콘을 추가했습니다

- 카테고리 상세 페이지에서 메인페이지로 다시 이동할 경우 무한 렌더링되는 문제를 수정했습니다.
