### PR TITLE
fix: mysql connection pool 싱글톤으로 바꿈

### DIFF
--- a/server/db/share/connection.js
+++ b/server/db/share/connection.js
@@ -1,0 +1,13 @@
+import mysql2 from 'mysql2/promise';
+import { dbConf } from '../share/db.config';
+
+let db = null;
+
+function initPool() {
+  if (!db) {
+    db = mysql2.createPool(dbConf);
+  }
+  return db;
+}
+
+export { initPool };

--- a/server/db/share/execute-query.js
+++ b/server/db/share/execute-query.js
@@ -1,14 +1,16 @@
-import { dbConf } from '../share/db.config';
-import mysql2 from 'mysql2/promise';
+import { initPool } from './connection';
 
 export default async function executeQuery(query) {
+  const pool = initPool();
+  const connection = await pool.getConnection();
   try {
-    const pool = mysql2.createPool(dbConf);
-    const connection = await pool.getConnection();
     const [rows] = await connection.query(query);
-    connection.release();
+    await connection.commit();
     return rows;
   } catch (err) {
+    await connection.rollback();
     throw err;
+  } finally {
+    await connection.release();
   }
 }


### PR DESCRIPTION
## 체크리스트

- [x] 파일명/폴더명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 관련된 label 추가했는지 확인

## 설명
오래 실행하다 보면 max connection 에러가 나오는 문제를 해결하기 위하여
pool 을 싱글톤으로 바꿔서 한 사용자당 한번만 연결하도록
